### PR TITLE
Copy over CI as used by shotover

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,58 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Cancel already running jobs
+concurrency:
+  group: build_and_test_${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu 20.04 - Release
+            runner: ubuntu-20.04
+            cargo_flags: --release
+
+          - name: Ubuntu 20.04 - Debug
+            runner: ubuntu-20.04
+            cargo_flags:
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        # rust-cache already handles all the sane defaults for caching rust builds.
+        # However because we are running seperate debug/release builds in parallel,
+        # we also need to add the runner and cargo_flags to the key so that a seperate cache is used.
+        # Otherwise only the last build to finish would get saved to the cache.
+        key: ${{ matrix.runner }} - ${{ matrix.cargo_flags }}
+    - name: Install cargo-hack
+      run: cargo install cargo-hack --version 0.5.8
+    - name: Check `cargo fmt` was run
+      run: cargo fmt --all -- --check
+    - name: Ensure that all crates compile and have no warnings under every possible combination of features
+      # some things to explicitly point out:
+      # * clippy also reports rustc warnings and errors
+      # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
+      run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_flags }} -- -D warnings
+    - name: Ensure that tests pass
+      run: cargo test ${{ matrix.cargo_flags }} --all-features -- --include-ignored --nocapture
+    - name: Ensure that tests did not create or modify any files that arent .gitignore'd
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git status
+          exit 1
+        fi

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.71"
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
This is all purely suggestion, I understand that adding too much process during the prototyping phase can really slow things down.
So feel free to take the bits that you like and leave out the bits you dont.
You could also merge it and then ignore the failures until your ready to commit to abiding by the CI.

This PR takes the CI configuration we use from shotover and strips it down to the bits that would be useful for this project.
It will currently fail due to the unaddressed warnings and clippy lints, I'll let you address the warnings, I'm not sure whether the unused code should be removed or `#[allow(dead_code)]`d

I'll break down what it does:
* `actions/checkout@v3` - git clones the project so we can run checks on it, necessary
* `Swatinem/rust-cache@v2` - caches all the rust build artifacts, free faster CI!
* `Install cargo-hack` - a tool that lets us check compilation+warnings with all combinations of cargo features exposed by the crate. We dont have any cargo features in this project yet but the future proofing is nice. I dont bother with running this tool locally but its very nice for catching edge cases in CI.
* `cargo fmt --all -- --check` - asserts that `cargo fmt --all` has been run on the codebase, cargo-fmt is widely accepted as the standard formatter for rust so its a good idea to get used to its formatting, strongly recommended
   + I enable vs code's `format on save` setting so I dont have to think about running it manually.
* `cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_flags }} -- -D warnings` - asserts that all clippy lints pass, recomended
    + to run locally dont bother with `cargo-hack`, just do `cargo clippy --all-targets`
    + to have clippy automatically fix a subset of its warnings you can run `cargo clippy --all-targets --fix`
    + if you find clippy overbearing you could downgrade this check to just rustc warnings by replacing it with: `cargo hack --feature-powerset check --all-targets --locked ${{ matrix.cargo_flags }}`
    + new rustc and clippy warnings can be introduced in new rust versions, to avoid these breaking CI I have introduced a `rust-toolchain.toml` file. rustup will read this and pin your rustc version to the version specified in the file. This file will also make rustup automagically install rust-fmt and clippy for you.
    + even during prototyping I recommend keeping your codebase free of rustc warnings since some warnings reveal critical bugs, things like missing `.await` or `.unwrap()` can lead to hard to track down bugs, but rustc produces warnings for them.
* `cargo test ${{ matrix.cargo_flags }} --all-features -- --include-ignored --nocapture` - runs all your tests, currently there arent any tests but I'm sure you'll want to run them when you do have them, strongly recommended
* `Ensure that tests did not create or modify any files` - ensures the Cargo.lock is in sync with your Cargo.toml, strongly recommend.