### PR TITLE
File type detector

### DIFF
--- a/brro-compressor/src/utils/file_type_detector.rs
+++ b/brro-compressor/src/utils/file_type_detector.rs
@@ -1,0 +1,28 @@
+use std::fs::File;
+use std::io::{BufReader, Read, Result, Take, Error, ErrorKind};
+
+enum FileType {
+    WAV,
+    RAW,
+}
+
+fn is_wav(reader: &mut Take<BufReader<File>>) -> Result<bool> {
+    let mut buffer = [0u8; 12];
+    reader.read_exact(&mut buffer)?;
+    Ok(&buffer[..4] == b"RIFF" && &buffer[8..] == b"WAVE")
+}
+
+fn detect_file_type(filename: &str) -> Result<FileType> {
+    let file = File::open(filename)?;
+    let file_len = file.metadata()?.len();
+
+    if file_len < 12 {
+        return Err(Error::new(ErrorKind::InvalidData, "File is too short"));
+    }
+
+    if is_wav(&mut BufReader::new(file).take(12))? {
+        Ok(FileType::WAV)
+    } else {
+        Ok(FileType::RAW)
+    }
+}

--- a/brro-compressor/src/utils/mod.rs
+++ b/brro-compressor/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod reader;
 pub mod writer;
+mod file_type_detector;


### PR DESCRIPTION
### Overview:
This pull request introduces a method to automatically detect whether a given file is of type WAV or RAW. Instead of relying on external flags, this solution uses the inherent header structure of WAV files for detection, which can prove handy when parsing directories containing multiple file types.

### Changes:

- New Enum FileType: Added an enumeration with two variants: WAV and RAW to represent the possible file types.
- Function is_wav: A utility function that checks the header of a file to determine if it's a WAV file. It reads the initial 12 bytes of the file to match against the standard WAV header.
- Function detect_file_type: Main function to detect the type of file (WAV or RAW). It first checks the length of the file to ensure validity and then uses the is_wav function for WAV detection. If it's not a WAV file, it defaults to RAW.

### Error Handling:
Added an error condition to check if the file is too short (less than 12 bytes). In such cases, an InvalidData error is returned.