### PR TITLE
compressor outputs extensions

### DIFF
--- a/brro-compressor/src/main.rs
+++ b/brro-compressor/src/main.rs
@@ -30,7 +30,7 @@ fn process_args(input_path: &str, arguments: &Args) {
                 compressed = compressor::constant::constant(&optimizer_results_f);
             }
 
-            let file_name =  writer::replace_extension(&files.names[index], "txt)");
+            let file_name =  writer::replace_extension(&files.names[index], "bin");
             let new_path = base_dir.join(&file_name);
             let mut file = writer::create_streaming_writer(&new_path).expect("TODO: panic message");
             writer::write_data_to_stream(&mut file, &compressed).expect("Failed to write compressed data");


### PR DESCRIPTION
This PR proposes a change in the extension of our output files from .txt to .bin. The primary reason for this modification is to reflect the nature of our outputs more accurately as we are now outputting binary data