### PR TITLE
brro-compressor: make clap handle parsing paths for us

### DIFF
--- a/brro-compressor/src/main.rs
+++ b/brro-compressor/src/main.rs
@@ -1,36 +1,39 @@
-use std::path::Path;
-use clap::{Parser, command, arg};
-use log::debug;
 use brro_compressor::compressor::Compressor;
+use brro_compressor::data::CompressedStream;
 use brro_compressor::optimizer;
+use brro_compressor::types::metric_tag::MetricTag;
 use brro_compressor::utils::reader;
 use brro_compressor::utils::writer;
-use brro_compressor::data::CompressedStream;
-use brro_compressor::types::metric_tag::MetricTag;
+use clap::{arg, command, Parser};
+use log::debug;
+use std::path::Path;
+use std::path::PathBuf;
 
 /// Processes the given input based on the provided arguments.
 /// If `arguments.directory` is true, it processes all files in the directory.
 /// Otherwise, it processes the individual file.
-fn process_args(input_path: &str, arguments: &Args) {
-    let path = Path::new(input_path);
-
+fn process_args(arguments: &Args) {
     // If the input path points to a directory
     if arguments.directory {
-        process_directory(path, arguments);
+        process_directory(arguments);
     }
     // If the input path points to a single file
     else {
-        process_single_file(path, arguments);
+        process_single_file(arguments);
     }
 }
 
 /// Processes all files in a given directory.
-fn process_directory(path: &Path, arguments: &Args) {
-    let new_name = format!("{}-compressed", path.file_name().unwrap().to_string_lossy());
-    let base_dir = path.with_file_name(new_name);
+fn process_directory(arguments: &Args) {
+    let new_name = format!(
+        "{}-compressed",
+        arguments.input.file_name().unwrap().to_string_lossy()
+    );
+    let base_dir = arguments.input.with_file_name(new_name);
 
     writer::initialize_directory(&base_dir).expect("Failed to initialize directory");
-    let files = reader::stream_reader(path).expect("Failed to read files from directory");
+    let files =
+        reader::stream_reader(&arguments.input).expect("Failed to read files from directory");
 
     for (index, data) in files.contents.iter().enumerate() {
         let (vec_data, tag) = data;
@@ -43,14 +46,15 @@ fn process_directory(path: &Path, arguments: &Args) {
 }
 
 /// Processes a single file.
-fn process_single_file(path: &Path, arguments: &Args) {
-    if let Some((vec, tag)) = reader::read_file(path).expect("Failed to read file") {
+fn process_single_file(arguments: &Args) {
+    if let Some((vec, tag)) = reader::read_file(&arguments.input).expect("Failed to read file") {
         let compressed_data = compress_data(&vec, &tag, arguments);
 
-        if let Some(filename_osstr) = path.file_name() {
+        if let Some(filename_osstr) = arguments.input.file_name() {
             if let Some(filename_str) = filename_osstr.to_str() {
-                let new_filename_string = writer::replace_extension(&filename_str.to_string(), "bin");
-                let new_path = path.parent().unwrap().join(new_filename_string);
+                let new_filename_string =
+                    writer::replace_extension(&filename_str.to_string(), "bin");
+                let new_path = arguments.input.parent().unwrap().join(new_filename_string);
                 write_compressed_data_to_path(&compressed_data, &new_path);
             }
         }
@@ -74,16 +78,16 @@ fn compress_data(vec: &Vec<f64>, tag: &MetricTag, arguments: &Args) -> Vec<u8> {
 
 /// Writes the compressed data to the specified path.
 fn write_compressed_data_to_path(compressed: &[u8], path: &Path) {
-    let mut file = writer::create_streaming_writer(path).expect("Failed to create a streaming writer");
+    let mut file =
+        writer::create_streaming_writer(path).expect("Failed to create a streaming writer");
     writer::write_data_to_stream(&mut file, compressed).expect("Failed to write compressed data");
 }
-
 
 #[derive(Parser, Default, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// input file
-    input: String,
+    input: PathBuf,
 
     #[arg(short, action)]
     directory: bool,
@@ -101,5 +105,5 @@ fn main() {
     env_logger::init();
     let arguments = Args::parse();
     debug!("{:?}", arguments);
-    process_args(&arguments.input, &arguments);
+    process_args(&arguments);
 }


### PR DESCRIPTION
The advantage of this approach is we can keep the path in the arguments struct which makes it really easy to trace that path is a user input (and which user input) because we can directly see that its a field in the Args struct right up until it gets used.