### PR TITLE
Add Input Type Autodetection and FFT CLI Argument

### DIFF
--- a/brro-compressor/src/main.rs
+++ b/brro-compressor/src/main.rs
@@ -85,7 +85,7 @@ fn process_single_file(arguments: &Args) -> Result<(), std::io::Error>  {
                 let new_filename_string =
                     writer::replace_extension(&filename_str.to_string(), "bro");
                 let new_path = arguments.input.parent().unwrap().join(new_filename_string);
-                write_compressed_data_to_path(&compressed_data, &new_path);
+                write_compressed_data_to_path(&compressed_data, &new_path)?;
             }
         }
     }


### PR DESCRIPTION
**Summary**:
This pull request introduces input type autodetection and adds the FFT as a CLI argument. It improves the error handling mechanism by propagating errors instead of using .expect(), and ensures the right number of arguments is provided by the user.

**Changes**:

- Input Type Autodetection:

Implemented a mechanism to autodetect the input type. The program now automatically identifies the type of the input, reducing the need for manual selection.

- FFT CLI Argument:

Added FFT as a CLI argument.

- Arguments Count Validation:

Integrated a check for the number of provided arguments. This addition ensures users provide the correct number of arguments.

- Error Propagation:

Transitioned from using .expect() to an error propagation.

Any feedback is welcome!
