### PR TITLE
FFT compressor improvements

### DIFF
--- a/brro-compressor/src/compressor/mod.rs
+++ b/brro-compressor/src/compressor/mod.rs
@@ -24,7 +24,7 @@ impl Compressor {
     pub fn compress(&self, data: &[f64] ) -> Vec<u8> {
         match self {
             Compressor::Noop => noop(data),
-            Compressor::FFT => fft(data, 8, 0.0, 10.0), // TODO: Remove the placeholders
+            Compressor::FFT => fft(data),
             Compressor::Constant => constant(data),
             _ => todo!(),
         }


### PR DESCRIPTION
Currently the FFT compressor has a different signature than all the other compressors. One idea was to get the optimizer to do some work and set the FFT parametrization via other means.

So, the rational for this PR is the following:

1) FFT have the same base function signature that the others, so a call to FFT will have a sane default
2) New FFT signatures for dealing with either set frequencies or maximum error allowed
    - This can be called explicitly when required without interfering with a normal flow of the code (They are exceptional cases anyway)
    
Bugfixes:

- FFT ID variable name
- Greatly increased the performance of the FFT calculations for best error approximations (Still heavy)

Tests were adjusted for the new signatures and new defaults.