### PR TITLE
Poly performance improvements

### DIFF
--- a/brro-compressor/src/compressor/polynomial.rs
+++ b/brro-compressor/src/compressor/polynomial.rs
@@ -226,7 +226,7 @@ impl Polynomial {
     pub fn to_data(&self, frame_size: usize) -> Vec<f64> {
         if self.max == self.min { 
             debug!("Same max and min, faster decompression!");
-            return vec![self.max as f64; frame_size];
+            return vec![self.max; frame_size];
         }
         match self.id {
             PolynomialType::Idw => self.idw_to_data(frame_size),


### PR DESCRIPTION
Got tired of all the mambo-jambo of getting the min and max into the right places and things going off everywhere.

So, run a compression run with that buggy code, removed the code, run the compression run again, and the loss of compression is less than 1%. So I'll take simple code over a >1% improvement.

And killed other bugs around.