### PR TITLE
Issue-118, Auto compressor selection fix

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80"
+channel = "1.81"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
This PR provides a fix for a bug described in #118. 

`CompressorFrame::compress_best` picks the best compressor by comparing its space usage, but it doesn't consider the `max_error` allowed. This PR fixes this problem by filtering the results by `max_error` before picking a compressor that compresses the best.

Closes #118