### PR TITLE
Add release infra

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+---
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  prepublish-check:
+    name: "Check that the project is releaseable"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run checks
+        run: atsc/release/is_releasable.sh
+
+  publish-binary:
+    name: "Publish Binary to GitHub"
+    needs: prepublish-check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build & test
+        run: atsc/release/build_release.sh
+      - name: Publish
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false
+          files: |
+            *.tar.gz

--- a/atsc/release/build_release.sh
+++ b/atsc/release/build_release.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $SCRIPT_DIR
+
+cargo build --release
+
+mkdir -p atsc
+cp ../../target/release/atsc atsc
+
+# extract the crate version from Cargo.toml
+CRATE_VERSION="$(cargo metadata --format-version 1 --offline --no-deps | jq -c -M -r '.packages[] | select(.name == "atsc") | .version')"
+tar -cvzf out.tar.gz atsc
+mv out.tar.gz atsc-linux_amd64-${CRATE_VERSION}.tar.gz
+
+rm -rf atsc

--- a/atsc/release/is_releasable.sh
+++ b/atsc/release/is_releasable.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+TAG=$(git tag --points-at HEAD)
+
+if [ -z "$TAG" ];
+then
+    echo "Failed: The current commit has no git tags"
+    exit 1
+fi
+
+if [[ $TAG == *$'\n'* ]];
+then
+    echo "Failed: multiple git tags are on the latest commit, but only one tag is allowed"
+    echo "$TAG"
+    exit 1
+fi
+
+TAG_VERSION=$(echo $TAG | sed -e "s/^v//")
+
+if [ -z "$TAG_VERSION" ];
+then
+    echo "Failed: git tag not valid: '$TAG'"
+    exit 1
+fi
+
+BIN_VERSION="$(cargo metadata --format-version 1 --offline --no-deps | jq -c -M -r '.packages[] | select(.name == "atsc") | .version')"
+if [ "$TAG_VERSION" != "$BIN_VERSION" ];
+then
+    echo "Failed: git tag '$TAG_VERSION' did not match atsc version '$BIN_VERSION'"
+    exit 1
+fi
+
+
+echo "ATSC repository is ready for publishing"


### PR DESCRIPTION
This PR copies over the release infra from the shotover project, stripping out anything unneeded and changing shotover names to atsc.

This approach is outdated and I highly recommend moving to https://github.com/axodotdev/cargo-dist in the future.
But this was the quickest solution I could put together.