### PR TITLE
Fix binary release and release ATSC 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atsc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "average",
  "bincode",

--- a/atsc/Cargo.toml
+++ b/atsc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsc"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Carlos Rolo <carlos.rolo@netapp.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/atsc/release/build_release.sh
+++ b/atsc/release/build_release.sh
@@ -14,6 +14,6 @@ cp ../../target/release/atsc atsc
 # extract the crate version from Cargo.toml
 CRATE_VERSION="$(cargo metadata --format-version 1 --offline --no-deps | jq -c -M -r '.packages[] | select(.name == "atsc") | .version')"
 tar -cvzf out.tar.gz atsc
-mv out.tar.gz atsc-linux_amd64-${CRATE_VERSION}.tar.gz
+mv out.tar.gz ../../atsc-linux_amd64-${CRATE_VERSION}.tar.gz
 
 rm -rf atsc


### PR DESCRIPTION
Although this was code was succesfully copied from the shotover, it was actually broken in shotover for over a year. :smiling_face_with_tear: 
This PR SHOULD fix the issue, lets see.

The error can be seen in the logs of the release workflow:
![image](https://github.com/user-attachments/assets/bab8db91-ef51-4e2f-8c4f-624f0a2c54c7)
The .tar.gz file is created in a subfolder instead of the root and so the next stage of the workflow cant find it because its checking the root.