### PR TITLE
Added version comparison and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/settings.json
 
 .idea
+.vscode/launch.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atsc"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "average",
  "bincode",
@@ -119,6 +119,7 @@ dependencies = [
  "splines",
  "tempfile",
  "thiserror",
+ "version-compare",
  "wavbrro",
 ]
 
@@ -1399,6 +1400,12 @@ name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,6 @@ dependencies = [
  "splines",
  "tempfile",
  "thiserror",
- "version-compare",
  "wavbrro",
 ]
 
@@ -1400,12 +1399,6 @@ name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
-
-[[package]]
-name = "version-compare"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/atsc/Cargo.toml
+++ b/atsc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsc"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Carlos Rolo <carlos.rolo@netapp.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -24,6 +24,7 @@ inverse_distance_weight = "0.1.1"
 num-traits = "0.2"
 csv = "1.3.1"
 thiserror = "2.0.3"
+version-compare = "0.1"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/atsc/Cargo.toml
+++ b/atsc/Cargo.toml
@@ -24,7 +24,6 @@ inverse_distance_weight = "0.1.1"
 num-traits = "0.2"
 csv = "1.3.1"
 thiserror = "2.0.3"
-version-compare = "0.1"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/atsc/src/data.rs
+++ b/atsc/src/data.rs
@@ -79,8 +79,8 @@ impl CompressedStream {
     pub fn to_bytes(self) -> Vec<u8> {
         let mut out = Vec::new();
         let config = BinConfig::get();
-        out.extend_from_slice(&self.header.to_bytes());
-        out.extend_from_slice(&bincode::encode_to_vec(self.data_frames, config).unwrap());
+        &self.header.to_bytes(&mut out);
+        bincode::encode_into_std_write(self.data_frames, &mut out, config).unwrap();
         out
     }
 

--- a/atsc/src/data.rs
+++ b/atsc/src/data.rs
@@ -79,7 +79,7 @@ impl CompressedStream {
     pub fn to_bytes(self) -> Vec<u8> {
         let mut out = Vec::new();
         let config = BinConfig::get();
-        &self.header.to_bytes(&mut out);
+        self.header.to_bytes(&mut out);
         bincode::encode_into_std_write(self.data_frames, &mut out, config).unwrap();
         out
     }

--- a/atsc/src/data.rs
+++ b/atsc/src/data.rs
@@ -40,6 +40,7 @@ impl CompressedStream {
         compressor_frame.compress(chunk);
         compressor_frame.close();
         self.data_frames.push(compressor_frame);
+        self.header.add_frame();
     }
 
     /// Compress a chunk of data with a specific compressor adding it as a new frame to the current stream
@@ -48,6 +49,7 @@ impl CompressedStream {
         compressor_frame.compress(chunk);
         compressor_frame.close();
         self.data_frames.push(compressor_frame);
+        self.header.add_frame();
     }
 
     /// Compress a chunk of data with a specific compressor adding it as a new frame to the current stream
@@ -70,6 +72,7 @@ impl CompressedStream {
         }
         compressor_frame.close();
         self.data_frames.push(compressor_frame);
+        self.header.add_frame();
     }
 
     /// Transforms the whole CompressedStream into bytes to be written to a file
@@ -127,6 +130,18 @@ mod tests {
     }
 
     #[test]
+    fn test_frame_count() {
+        let vector1 = vec![1.0; 1024];
+        let mut cs = CompressedStream::new();
+        cs.compress_chunk_with(&vector1, Compressor::Constant);
+        println!("{:?}", cs.header.get_frame_count());
+        assert_eq!(
+            usize::from(cs.header.get_frame_count()),
+            cs.data_frames.len()
+        );
+    }
+
+    #[test]
     fn test_to_bytes() {
         let vector1 = vec![1.0; 1024];
         let mut cs = CompressedStream::new();
@@ -134,7 +149,7 @@ mod tests {
         let b = cs.to_bytes();
         assert_eq!(
             b,
-            [66, 82, 82, 79, 5, 48, 46, 55, 46, 50, 0, 1, 41, 251, 0, 4, 3, 3, 30, 3, 1]
+            [66, 82, 82, 79, 1, 0, 0, 0, 1, 1, 41, 251, 0, 4, 3, 3, 30, 3, 1]
         );
     }
 

--- a/atsc/src/data.rs
+++ b/atsc/src/data.rs
@@ -22,7 +22,7 @@ use log::debug;
 
 #[derive(Encode, Decode, Debug, Clone)]
 pub struct CompressedStream {
-    header: CompressorHeader,
+    pub header: CompressorHeader,
     data_frames: Vec<CompressorFrame>,
 }
 
@@ -120,7 +120,10 @@ mod tests {
         let mut cs = CompressedStream::new();
         cs.compress_chunk_with(&vector1, Compressor::Constant);
         let b = cs.to_bytes();
-        assert_eq!(b, [66, 82, 82, 79, 0, 1, 41, 251, 0, 4, 3, 3, 30, 3, 1]);
+        assert_eq!(
+            b,
+            [66, 82, 82, 79, 5, 48, 46, 55, 46, 50, 0, 1, 41, 251, 0, 4, 3, 3, 30, 3, 1]
+        );
     }
 
     #[test]

--- a/atsc/src/header.rs
+++ b/atsc/src/header.rs
@@ -18,7 +18,7 @@ use log::{debug, trace};
 use std::panic;
 
 /*  The current file version.
-    On file read, compressors check the version and uncompress accordingly to that (of fail)
+    On file read, compressors check the version and uncompress accordingly to that (or fail)
 */
 const CURRENT_VERSION: u32 = 1;
 #[derive(Debug, Clone)]
@@ -33,7 +33,7 @@ fn verify_header_versions(version: u32) {
     trace!("Versions: c:{} h:{}", current_version, version);
     match current_version.cmp(&version) {
         std::cmp::Ordering::Less => panic!(
-            "Can't decompress! File is version ({}) is higher than compressor version ({})!",
+            "Can't decompress! File is version ({}) which is higher than compressor version ({})!",
             version, current_version
         ),
         std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => {
@@ -59,17 +59,13 @@ impl CompressorHeader {
         self.frame_count
     }
 
-    pub fn to_bytes(&self) -> Vec<u8> {
-        // Converts header to a byte vector, little endian
-        let mut vec = Vec::new();
+    pub fn to_bytes(&self, writer: &mut Vec<u8>) {
         // Add initial_segment
-        vec.extend_from_slice(&self.initial_segment);
+        writer.extend_from_slice(&self.initial_segment);
         // Add version (u32 as 4 bytes)
-        vec.extend_from_slice(&self.version.to_le_bytes());
+        writer.extend_from_slice(&self.version.to_le_bytes());
         // Add frame_count
-        vec.push(self.frame_count);
-
-        vec
+        writer.push(self.frame_count);
     }
 
     pub fn from_bytes(data: [u8; 9]) -> Self {

--- a/atsc/src/header.rs
+++ b/atsc/src/header.rs
@@ -39,7 +39,7 @@ impl Decode for CompressorHeader {
         };
         let current_version = env!("CARGO_PKG_VERSION").to_string();
         trace!("Versions: c:{} h:{}", current_version, header.version);
-        match compare(current_version.clone(), header.version.clone()) {
+        match compare(&current_version, &header.version) {
             Ok(Cmp::Lt) => panic!(
                 "Can't decompress! File is version ({}) is higher than compressor version ({})!",
                 header.version, current_version

--- a/atsc/src/header.rs
+++ b/atsc/src/header.rs
@@ -25,7 +25,6 @@ const CURRENT_VERSION: u32 = 1;
 pub struct CompressorHeader {
     initial_segment: [u8; 4],
     pub version: u32,
-    // We should go unsigned
     frame_count: u8,
 }
 
@@ -48,7 +47,6 @@ impl CompressorHeader {
         CompressorHeader {
             initial_segment: *b"BRRO",
             version: CURRENT_VERSION,
-            // We have to limit the bytes of the header
             frame_count: 0,
         }
     }

--- a/atsc/src/header.rs
+++ b/atsc/src/header.rs
@@ -14,16 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::panic;
-
-//use bincode::{Decode, Encode};
 use log::{debug, trace};
+use std::panic;
 
 /*  The current file version.
     On file read, compressors check the version and uncompress accordingly to that (of fail)
 */
 const CURRENT_VERSION: u32 = 1;
-/* Encode,  */
 #[derive(Debug, Clone)]
 pub struct CompressorHeader {
     initial_segment: [u8; 4],
@@ -45,35 +42,6 @@ fn verify_header_versions(version: u32) {
         }
     }
 }
-/*
-impl Decode for CompressorHeader {
-    fn decode<__D: ::bincode::de::Decoder>(
-        decoder: &mut __D,
-    ) -> Result<Self, ::bincode::error::DecodeError> {
-        let header = Self {
-            initial_segment: Decode::decode(decoder)?,
-            version: Decode::decode(decoder)?,
-            frame_count: Decode::decode(decoder)?,
-        };
-        verify_header_versions(&header);
-        Ok(header)
-    }
-}
-
-impl<'__de> ::bincode::BorrowDecode<'__de> for CompressorHeader {
-    fn borrow_decode<__D: ::bincode::de::BorrowDecoder<'__de>>(
-        decoder: &mut __D,
-    ) -> Result<Self, ::bincode::error::DecodeError> {
-        let header = Self {
-            initial_segment: bincode::BorrowDecode::borrow_decode(decoder)?,
-            version: bincode::BorrowDecode::borrow_decode(decoder)?,
-            frame_count: bincode::BorrowDecode::borrow_decode(decoder)?,
-        };
-        verify_header_versions(&header);
-        Ok(header)
-    }
-}
-*/
 
 impl CompressorHeader {
     pub fn new() -> Self {
@@ -87,6 +55,10 @@ impl CompressorHeader {
 
     pub fn add_frame(&mut self) {
         self.frame_count += 1;
+    }
+
+    pub fn get_frame_count(&mut self) -> u8 {
+        self.frame_count
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/atsc/src/header.rs
+++ b/atsc/src/header.rs
@@ -14,19 +14,72 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use bincode::{Decode, Encode};
+use std::panic;
 
-#[derive(Encode, Decode, Debug, Clone)]
+use bincode::{Decode, Encode};
+use log::{debug, trace};
+use version_compare::{compare, Cmp};
+
+#[derive(Encode, Debug, Clone)]
 pub struct CompressorHeader {
     initial_segment: [u8; 4],
+    pub version: String,
     // We should go unsigned
     frame_count: i16,
 }
 
+impl Decode for CompressorHeader {
+    fn decode<__D: ::bincode::de::Decoder>(
+        decoder: &mut __D,
+    ) -> Result<Self, ::bincode::error::DecodeError> {
+        let header = Self {
+            initial_segment: Decode::decode(decoder)?,
+            version: Decode::decode(decoder)?,
+            frame_count: Decode::decode(decoder)?,
+        };
+        let current_version = env!("CARGO_PKG_VERSION").to_string();
+        trace!("Versions: c:{} h:{}", current_version, header.version);
+        match compare(current_version.clone(), header.version.clone()) {
+            Ok(Cmp::Lt) => panic!(
+                "Can't decompress! File is version ({}) is higher than compressor version ({})!",
+                header.version, current_version
+            ),
+            Ok(Cmp::Eq | Cmp::Gt) => debug!("File version: {}", header.version),
+            _ => panic!("Wrong version number!"),
+        }
+        Ok(header)
+    }
+}
+
+impl<'__de> ::bincode::BorrowDecode<'__de> for CompressorHeader {
+    fn borrow_decode<__D: ::bincode::de::BorrowDecoder<'__de>>(
+        decoder: &mut __D,
+    ) -> Result<Self, ::bincode::error::DecodeError> {
+        let header = Self {
+            initial_segment: bincode::BorrowDecode::borrow_decode(decoder)?,
+            version: bincode::BorrowDecode::borrow_decode(decoder)?,
+            frame_count: bincode::BorrowDecode::borrow_decode(decoder)?,
+        };
+        let current_version = env!("CARGO_PKG_VERSION").to_string();
+        trace!("Versions: c:{} h:{}", current_version, header.version);
+        match compare(current_version.clone(), header.version.clone()) {
+            Ok(Cmp::Lt) => panic!(
+                "Can't decompress! File is version ({}) is higher than compressor version ({})!",
+                header.version, current_version
+            ),
+            Ok(Cmp::Eq | Cmp::Gt) => debug!("File version: {}", header.version),
+            _ => panic!("Wrong version number!"),
+        }
+        Ok(header)
+    }
+}
+
 impl CompressorHeader {
     pub fn new() -> Self {
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
         CompressorHeader {
             initial_segment: *b"BRRO",
+            version: VERSION.to_string(),
             // We have to limit the bytes of the header
             frame_count: 0,
         }
@@ -34,5 +87,50 @@ impl CompressorHeader {
 
     pub fn add_frame(&mut self) {
         self.frame_count += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compressor::Compressor;
+    use crate::data::CompressedStream;
+
+    #[test]
+    fn test_same_version() {
+        let vector1 = vec![1.0; 1024];
+        let mut cs = CompressedStream::new();
+        cs.compress_chunk_with(&vector1, Compressor::Constant);
+        let b = cs.to_bytes();
+        let cs2 = CompressedStream::from_bytes(&b);
+        assert_eq!(
+            compare(env!("CARGO_PKG_VERSION").to_string(), cs2.header.version),
+            Ok(Cmp::Eq)
+        );
+    }
+
+    #[test]
+    fn test_smaller_version() {
+        let vector1 = vec![1.0; 1024];
+        let mut cs = CompressedStream::new();
+        cs.header.version = "0.1.0".to_owned();
+        cs.compress_chunk_with(&vector1, Compressor::Constant);
+        let b = cs.to_bytes();
+        let cs2 = CompressedStream::from_bytes(&b);
+        assert_eq!(
+            compare(env!("CARGO_PKG_VERSION").to_string(), cs2.header.version),
+            Ok(Cmp::Gt)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "is higher than compressor version")]
+    fn test_higher_version() {
+        let vector1 = vec![1.0; 1024];
+        let mut cs = CompressedStream::new();
+        cs.header.version = "9.9.9".to_owned();
+        cs.compress_chunk_with(&vector1, Compressor::Constant);
+        let b = cs.to_bytes();
+        CompressedStream::from_bytes(&b);
     }
 }


### PR DESCRIPTION
Closes #146

This PR addresses issue #146 in the following way:

1. Adds Version information in the `CompressorHeader` (Extracted from `Cargo.toml`)
2. On Decoding checks the version of the file against the version of the compressor.
  2.1 Doesn't allow decompression of higher version files by lower version compressor (Should it?)
3. Add tests for the compression/decompression
4. Minor version bump to start tagging the files where the header was introduced. 