### PR TITLE
Add Run Length Encoding (RLE) as a compression option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/settings.json
 
 .idea
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Internally ATSC uses the following methods for time series fitting:
 * Constant
 * Interpolation - Catmull-Rom
 * Interpolation - Inverse Distance Weight
-* RLE (Run Lenght Encoder)
+* RLE (Run Length Encoder)
 
 For a more detailed insight into ATSC read the paper here: [ATSC - A novel approach to time-series compression](https://github.com/instaclustr/atsc/tree/main/paper/ATCS-AdvancedTimeSeriesCompressor.pdf)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Internally ATSC uses the following methods for time series fitting:
 * Constant
 * Interpolation - Catmull-Rom
 * Interpolation - Inverse Distance Weight
+* RLE (Run Lenght Encoder)
 
 For a more detailed insight into ATSC read the paper here: [ATSC - A novel approach to time-series compression](https://github.com/instaclustr/atsc/tree/main/paper/ATCS-AdvancedTimeSeriesCompressor.pdf)
 

--- a/atsc/src/compressor/mod.rs
+++ b/atsc/src/compressor/mod.rs
@@ -23,11 +23,13 @@ use self::constant::{constant_compressor, constant_to_data};
 use self::fft::{fft, fft_compressor, fft_to_data};
 use self::noop::{noop, noop_to_data};
 use self::polynomial::{polynomial, polynomial_allowed_error, to_data, PolynomialType};
+use self::rle::{rle_compressor, rle_to_data};
 
 pub mod constant;
 pub mod fft;
 pub mod noop;
 pub mod polynomial;
+pub mod rle;
 
 #[derive(Encode, Decode, Default, Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum Compressor {
@@ -38,6 +40,7 @@ pub enum Compressor {
     Constant,
     Polynomial,
     Auto,
+    RLE,
 }
 
 /// Struct to store the results of a compression round. Will be used to pick the best compressor.
@@ -65,6 +68,7 @@ impl Compressor {
             Compressor::Constant => constant_compressor(data, stats).compressed_data,
             Compressor::Polynomial => polynomial(data, PolynomialType::Polynomial),
             Compressor::Idw => polynomial(data, PolynomialType::Idw),
+            Compressor::RLE => rle_compressor(data),
             _ => todo!(),
         }
     }
@@ -82,6 +86,7 @@ impl Compressor {
             Compressor::Idw => {
                 polynomial_allowed_error(data, max_error, PolynomialType::Idw).compressed_data
             }
+            Compressor::RLE => rle_compressor(data).compressed_data,
             _ => todo!(),
         }
     }

--- a/atsc/src/compressor/mod.rs
+++ b/atsc/src/compressor/mod.rs
@@ -68,7 +68,7 @@ impl Compressor {
             Compressor::Constant => constant_compressor(data, stats).compressed_data,
             Compressor::Polynomial => polynomial(data, PolynomialType::Polynomial),
             Compressor::Idw => polynomial(data, PolynomialType::Idw),
-            Compressor::RLE => rle_compressor(data),
+            Compressor::RLE => rle_compressor(data, stats).compressed_data,
             _ => todo!(),
         }
     }
@@ -86,7 +86,7 @@ impl Compressor {
             Compressor::Idw => {
                 polynomial_allowed_error(data, max_error, PolynomialType::Idw).compressed_data
             }
-            Compressor::RLE => rle_compressor(data).compressed_data,
+            Compressor::RLE => rle_compressor(data, stats).compressed_data,
             _ => todo!(),
         }
     }
@@ -112,6 +112,7 @@ impl Compressor {
             Compressor::Constant => constant_to_data(samples, data),
             Compressor::Polynomial => to_data(samples, data),
             Compressor::Idw => to_data(samples, data),
+            Compressor::RLE => rle_to_data(samples, data),
             _ => todo!(),
         }
     }

--- a/atsc/src/compressor/mod.rs
+++ b/atsc/src/compressor/mod.rs
@@ -97,6 +97,7 @@ impl Compressor {
             Compressor::Noop => CompressorResult::new(noop(data), 0.0),
             Compressor::FFT => fft_compressor(data, max_error, stats),
             Compressor::Constant => constant_compressor(data, stats),
+            Compressor::RLE => rle_compressor(data, stats),
             Compressor::Polynomial => {
                 polynomial_allowed_error(data, max_error, PolynomialType::Polynomial)
             }

--- a/atsc/src/compressor/rle.rs
+++ b/atsc/src/compressor/rle.rs
@@ -28,13 +28,16 @@ const RLE_COMPRESSOR_ID: u8 = 60;
 
 /// Run Length Encoding compressor
 #[derive(PartialEq, Debug, Clone)]
-pub struct RLE {
+pub struct IndexRLE {
+    /// Compressor ID
     pub id: u8,
+    /// Index Based RLE. f64 is the value of the index, Vec<usize> is a vector where each value is the index of the value in the data
+    /// A series of [1,1,1,1,2,1,1,1,1] would have 1 as a value with indexes at 0 and 5.
     pub rle: Vec<(f64, Vec<usize>)>,
     bitdepth: Bitdepth,
 }
 
-impl Encode for RLE {
+impl Encode for IndexRLE {
     fn encode<__E: ::bincode::enc::Encoder>(
         &self,
         encoder: &mut __E,
@@ -63,7 +66,7 @@ impl Encode for RLE {
     }
 }
 
-impl Decode for RLE {
+impl Decode for IndexRLE {
     fn decode<__D: ::bincode::de::Decoder>(
         decoder: &mut __D,
     ) -> Result<Self, ::bincode::error::DecodeError> {
@@ -73,17 +76,26 @@ impl Decode for RLE {
             Bitdepth::U8 => {
                 debug!("Decoding as u8");
                 let rle_u8: Vec<(u8, Vec<usize>)> = Decode::decode(decoder)?;
-                RLE::rle_u8_into(rle_u8)
+                rle_u8
+                    .into_iter()
+                    .map(|(value, indices)| (value as f64, indices))
+                    .collect()
             }
             Bitdepth::I16 => {
                 debug!("Decoding as i16");
                 let rle_i16: Vec<(i16, Vec<usize>)> = Decode::decode(decoder)?;
-                RLE::rle_i16_into(rle_i16)
+                rle_i16
+                    .into_iter()
+                    .map(|(value, indices)| (value as f64, indices))
+                    .collect()
             }
             Bitdepth::I32 => {
                 debug!("Decoding as i32");
                 let rle_i32: Vec<(i32, Vec<usize>)> = Decode::decode(decoder)?;
-                RLE::rle_i32_into(rle_i32)
+                rle_i32
+                    .into_iter()
+                    .map(|(value, indices)| (value as f64, indices))
+                    .collect()
             }
             Bitdepth::F64 => {
                 debug!("Decoding as f64");
@@ -96,10 +108,10 @@ impl Decode for RLE {
     }
 }
 
-impl RLE {
+impl IndexRLE {
     // Helper functions to convert the RLE data to different types
     fn rle_as_u8(&self) -> Vec<(u8, Vec<usize>)> {
-        let mut result: Vec<(u8, Vec<usize>)> = Vec::new();
+        let mut result: Vec<(u8, Vec<usize>)> = Vec::with_capacity(self.rle.len());
         for (value, indices) in &self.rle {
             result.push((*value as u8, indices.clone()));
         }
@@ -107,7 +119,7 @@ impl RLE {
     }
 
     fn rle_as_i16(&self) -> Vec<(i16, Vec<usize>)> {
-        let mut result: Vec<(i16, Vec<usize>)> = Vec::new();
+        let mut result: Vec<(i16, Vec<usize>)> = Vec::with_capacity(self.rle.len());
         for (value, indices) in &self.rle {
             result.push((*value as i16, indices.clone()));
         }
@@ -115,33 +127,9 @@ impl RLE {
     }
 
     fn rle_as_i32(&self) -> Vec<(i32, Vec<usize>)> {
-        let mut result: Vec<(i32, Vec<usize>)> = Vec::new();
+        let mut result: Vec<(i32, Vec<usize>)> = Vec::with_capacity(self.rle.len());
         for (value, indices) in &self.rle {
             result.push((*value as i32, indices.clone()));
-        }
-        result
-    }
-
-    pub fn rle_u8_into(rle_u8: Vec<(u8, Vec<usize>)>) -> Vec<(f64, Vec<usize>)> {
-        let mut result: Vec<(f64, Vec<usize>)> = Vec::new();
-        for (value, indices) in &rle_u8 {
-            result.push((*value as f64, indices.clone()));
-        }
-        result
-    }
-
-    pub fn rle_i16_into(rle_i16: Vec<(i16, Vec<usize>)>) -> Vec<(f64, Vec<usize>)> {
-        let mut result: Vec<(f64, Vec<usize>)> = Vec::new();
-        for (value, indices) in &rle_i16 {
-            result.push((*value as f64, indices.clone()));
-        }
-        result
-    }
-
-    pub fn rle_i32_into(rle_i32: Vec<(i32, Vec<usize>)>) -> Vec<(f64, Vec<usize>)> {
-        let mut result: Vec<(f64, Vec<usize>)> = Vec::new();
-        for (value, indices) in &rle_i32 {
-            result.push((*value as f64, indices.clone()));
         }
         result
     }
@@ -163,10 +151,7 @@ impl RLE {
         while i < len {
             let value = data[i];
 
-            if i + 1 < len && data[i + 1] == value {
-                i += 1;
-                continue;
-            } else if i + 1 >= len || data[i + 1] != value {
+            if i + 1 >= len || data[i + 1] != value {
                 trace!("Value Change! Storing value: {}", value);
                 // Next value is different so store the current index
                 // First check if we have the value in the map
@@ -196,7 +181,7 @@ impl RLE {
             result.push((f64::from_bits(value), indices));
         }
         trace!("Vector: {:?}", result);
-        RLE {
+        IndexRLE {
             id: RLE_COMPRESSOR_ID,
             rle: result,
             bitdepth,
@@ -253,12 +238,12 @@ impl RLE {
 
 pub fn rle_compressor(data: &[f64], stats: DataStats) -> CompressorResult {
     debug!("Initializing RLE Compressor. Error and Stats provided");
-    let c = RLE::new(data, stats.bitdepth);
+    let c = IndexRLE::new(data, stats.bitdepth);
     CompressorResult::new(c.to_bytes(), 0.0)
 }
 
 pub fn rle_to_data(sample_number: usize, compressed_data: &[u8]) -> Vec<f64> {
-    let c = RLE::decompress(compressed_data);
+    let c = IndexRLE::decompress(compressed_data);
     c.to_data(sample_number)
 }
 
@@ -266,47 +251,72 @@ pub fn rle_to_data(sample_number: usize, compressed_data: &[u8]) -> Vec<f64> {
 mod tests {
     use super::*;
 
+    fn assert_roundtrip(raw_data: &[f64], encoded: &[u8]) {
+        let stats = DataStats::new(raw_data);
+        let rle = IndexRLE::new(raw_data, stats.bitdepth);
+        assert_eq!(rle.to_bytes(), encoded);
+
+        let decoded = rle_to_data(raw_data.len(), encoded);
+        assert_eq!(raw_data, decoded);
+    }
+
+    #[test]
+    fn test_index_rle_beats_regular_rle() {
+        // This test demonstrates a case where index-based RLE is more efficient than regular RLE.
+        // Regular RLE would encode this as (value, count) pairs, which can be less efficient
+        // when the data has sparse repetitions with large gaps between them.
+        //
+
+        let vector1 = vec![
+            1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        ];
+        let stats = DataStats::new(&vector1);
+        let rle = IndexRLE::new(&vector1, stats.bitdepth);
+
+        // Verify the encoded bytes are smaller than what regular RLE would produce.
+        let encoded = rle.to_bytes();
+        // RLE would do 7 pairs of (value, count) for vector1
+        // Size: 7 runs * 2 bytes per run (with value and index encoded as u8) = 14 bytes
+        let regular_rle_size = 16; // Regular RLE + 2 bytes from the Header
+        assert!(encoded.len() < regular_rle_size);
+
+        // Verify roundtrip correctness.
+        let decoded = rle_to_data(vector1.len(), &encoded);
+        assert_eq!(vector1, decoded);
+    }
+
     #[test]
     fn test_for_constant() {
-        let vector1 = vec![1.0; 512];
-        let stats = DataStats::new(&vector1);
-        let rle = RLE::new(&vector1, stats.bitdepth);
-        assert_eq!(rle.to_bytes(), [60, 3, 1, 1, 1, 0]);
+        assert_roundtrip(&[1.0; 512], &[60, 3, 1, 1, 1, 0]);
     }
 
     #[test]
     fn test_simple_validator() {
-        let vector1 = vec![
-            1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0,
-        ];
-        let stats = DataStats::new(&vector1);
-        let rle = RLE::new(&vector1, stats.bitdepth);
-        assert_eq!(
-            rle.to_bytes(),
-            [60, 3, 5, 1, 1, 0, 2, 1, 1, 3, 1, 3, 4, 1, 6, 5, 1, 10]
+        assert_roundtrip(
+            &[
+                1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0,
+            ],
+            &[60, 3, 5, 1, 1, 0, 2, 1, 1, 3, 1, 3, 4, 1, 6, 5, 1, 10],
         );
     }
 
     #[test]
     fn test_rle_u8() {
-        let vector1 = vec![
-            1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0, 3.0,
-            3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-        ];
-        let stats = DataStats::new(&vector1);
-        assert_eq!(
-            RLE::new(&vector1, stats.bitdepth).to_bytes(),
-            [60, 3, 3, 1, 3, 0, 6, 18, 2, 2, 4, 10, 3, 1, 12]
+        assert_roundtrip(
+            &[
+                1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0,
+                3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+            ],
+            &[60, 3, 3, 1, 3, 0, 6, 18, 2, 2, 4, 10, 3, 1, 12],
         );
     }
 
     #[test]
     fn test_rle_f64() {
-        let vector1 = vec![1.23456, 1.23456, 1.23456, 1.23456, 1.23456];
-        let stats = DataStats::new(&vector1);
-        assert_eq!(
-            RLE::new(&vector1, stats.bitdepth).to_bytes(),
-            [60, 0, 1, 56, 50, 143, 252, 193, 192, 243, 63, 1, 0]
+        assert_roundtrip(
+            &[1.23456, 1.23456, 1.23456, 1.23456, 1.23456],
+            &[60, 0, 1, 56, 50, 143, 252, 193, 192, 243, 63, 1, 0],
         );
     }
 
@@ -316,7 +326,7 @@ mod tests {
             1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0,
         ];
         let stats = DataStats::new(&vector1);
-        let c = RLE::new(&vector1, stats.bitdepth).to_bytes();
+        let c = IndexRLE::new(&vector1, stats.bitdepth).to_bytes();
         let c2 = rle_to_data(vector1.len(), &c);
         assert_eq!(vector1, c2);
     }
@@ -328,7 +338,7 @@ mod tests {
             3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
         ];
         let stats = DataStats::new(&vector1);
-        let c = RLE::new(&vector1, stats.bitdepth).to_bytes();
+        let c = IndexRLE::new(&vector1, stats.bitdepth).to_bytes();
         let c2 = rle_to_data(vector1.len(), &c);
         assert_eq!(vector1, c2);
     }

--- a/atsc/src/compressor/rle.rs
+++ b/atsc/src/compressor/rle.rs
@@ -1,0 +1,179 @@
+/*
+Copyright 2024 NetApp, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::{
+    compressor::CompressorResult,
+    optimizer::utils::{Bitdepth, DataStats},
+};
+
+use super::BinConfig;
+use bincode::{Decode, Encode};
+use log::debug;
+
+const CONSTANT_COMPRESSOR_ID: u8 = 60;
+
+/// Compressor frame for static data, stores the value and nothing else.
+#[derive(PartialEq, Debug, Clone)]
+pub struct Constant {
+    pub id: u8,
+    pub constant: f64,
+    // For internal use only
+    bitdepth: Bitdepth,
+}
+
+impl Encode for Constant {
+    fn encode<__E: ::bincode::enc::Encoder>(
+        &self,
+        encoder: &mut __E,
+    ) -> Result<(), ::bincode::error::EncodeError> {
+        Encode::encode(&self.id, encoder)?;
+        Encode::encode(&self.bitdepth, encoder)?;
+        match &self.bitdepth {
+            Bitdepth::U8 => {
+                debug!("Encoding as u8");
+                Encode::encode(&(self.constant as u8), encoder)?;
+            }
+            Bitdepth::I16 => {
+                debug!("Encoding as i16");
+                Encode::encode(&(self.constant as i16), encoder)?;
+            }
+            Bitdepth::I32 => {
+                debug!("Encoding as i32");
+                Encode::encode(&(self.constant as i32), encoder)?;
+            }
+            Bitdepth::F64 => {
+                debug!("Encoding as f64");
+                Encode::encode(&self.constant, encoder)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Decode for Constant {
+    fn decode<__D: ::bincode::de::Decoder>(
+        decoder: &mut __D,
+    ) -> Result<Self, ::bincode::error::DecodeError> {
+        let id = Decode::decode(decoder)?;
+        let bitdepth = Decode::decode(decoder)?;
+        let constant: f64 = match bitdepth {
+            Bitdepth::U8 => {
+                debug!("Decoding as u8");
+                let const_u8: u8 = Decode::decode(decoder)?;
+                const_u8 as f64
+            }
+            Bitdepth::I16 => {
+                debug!("Decoding as i16");
+                let const_i16: i16 = Decode::decode(decoder)?;
+                const_i16 as f64
+            }
+            Bitdepth::I32 => {
+                debug!("Decoding as i32");
+                let const_i32: i32 = Decode::decode(decoder)?;
+                const_i32 as f64
+            }
+            Bitdepth::F64 => {
+                debug!("Decoding as f64");
+                let const_f64: f64 = Decode::decode(decoder)?;
+                const_f64
+            }
+        };
+
+        Ok(Self {
+            id,
+            constant,
+            bitdepth,
+        })
+    }
+}
+
+impl RLE {
+    /// Creates a new instance of the Constant compressor with the size needed to handle the worst case
+    pub fn new(_sample_count: usize, constant_value: f64, bitdepth: Bitdepth) -> Self {
+        debug!("Constant compressor");
+        Constant {
+            id: CONSTANT_COMPRESSOR_ID,
+            constant: constant_value,
+            bitdepth,
+        }
+    }
+
+    /// Receives a data stream and generates a Constant
+    pub fn decompress(data: &[u8]) -> Self {
+        let config = BinConfig::get();
+        let (ct, _) = bincode::decode_from_slice(data, config).unwrap();
+        ct
+    }
+
+    /// This function transforms the structure into a Binary stream
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let config = BinConfig::get();
+        bincode::encode_to_vec(self, config).unwrap()
+    }
+
+    /// Returns an array of data. It creates an array of data the size of the frame with a constant value
+    /// and pushes the residuals to the right place.
+    pub fn to_data(&self, frame_size: usize) -> Vec<f64> {
+        let data = vec![self.constant; frame_size];
+        data
+    }
+}
+
+pub fn rle_compressor(data: &[f64], stats: DataStats) -> CompressorResult {
+    debug!("Initializing Constant Compressor. Error and Stats provided");
+    let c = Constant::new(data.len(), stats.min, stats.bitdepth);
+    CompressorResult::new(c.to_bytes(), 0.0)
+}
+
+pub fn rle_to_data(sample_number: usize, compressed_data: &[u8]) -> Vec<f64> {
+    let c = Constant::decompress(compressed_data);
+    c.to_data(sample_number)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constant_u8() {
+        let vector1 = vec![1.0, 1.0, 1.0, 1.0, 1.0];
+        let stats = DataStats::new(&vector1);
+        assert_eq!(
+            Constant::new(vector1.len(), stats.min, stats.bitdepth).to_bytes(),
+            [30, 3, 1]
+        );
+    }
+
+    #[test]
+    fn test_constant_f64() {
+        let vector1 = vec![1.23456, 1.23456, 1.23456, 1.23456, 1.23456];
+        let stats = DataStats::new(&vector1);
+        assert_eq!(
+            Constant::new(vector1.len(), stats.min, stats.bitdepth).to_bytes(),
+            [30, 0, 56, 50, 143, 252, 193, 192, 243, 63]
+        );
+    }
+
+    #[test]
+    fn test_compression() {
+        let vector1 = vec![1.0, 1.0, 1.0, 1.0, 1.0];
+        let stats = DataStats::new(&vector1);
+        let c = Constant::new(vector1.len(), stats.min, stats.bitdepth).to_bytes();
+        let c2 = constant_to_data(vector1.len(), &c);
+
+        assert_eq!(vector1, c2);
+    }
+}

--- a/atsc/src/compressor/rle.rs
+++ b/atsc/src/compressor/rle.rs
@@ -319,27 +319,4 @@ mod tests {
             &[60, 0, 1, 56, 50, 143, 252, 193, 192, 243, 63, 1, 0],
         );
     }
-
-    #[test]
-    fn test_compression() {
-        let vector1 = vec![
-            1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0,
-        ];
-        let stats = DataStats::new(&vector1);
-        let c = IndexRLE::new(&vector1, stats.bitdepth).to_bytes();
-        let c2 = rle_to_data(vector1.len(), &c);
-        assert_eq!(vector1, c2);
-    }
-
-    #[test]
-    fn test_compression_2() {
-        let vector1 = vec![
-            1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0, 3.0,
-            3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-        ];
-        let stats = DataStats::new(&vector1);
-        let c = IndexRLE::new(&vector1, stats.bitdepth).to_bytes();
-        let c2 = rle_to_data(vector1.len(), &c);
-        assert_eq!(vector1, c2);
-    }
 }

--- a/atsc/src/frame/mod.rs
+++ b/atsc/src/frame/mod.rs
@@ -74,7 +74,7 @@ impl CompressorFrame {
         // We need enough samples to do decent compression, minimum is 128 (2^7)
         let data_sample = COMPRESSION_SPEED[compression_speed] as usize;
         // Eligible compressors for use
-        let compressor_list = [Compressor::FFT, Compressor::Polynomial];
+        let compressor_list = [Compressor::FFT, Compressor::Polynomial, Compressor::RLE];
         // Do a statistical analysis of the data, let's see if we can pick a compressor out of this.
         let stats = DataStats::new(data);
         // Checking the statistical analysis and chose, if possible, a compressor

--- a/atsc/src/main.rs
+++ b/atsc/src/main.rs
@@ -129,10 +129,10 @@ fn process_single_file(mut file_path: PathBuf, arguments: &Args) -> Result<(), B
 /// Compresses the data based on the provided tag and arguments.
 fn compress_data(vec: &[f64], arguments: &Args) -> Vec<u8> {
     debug!("Compressing data!");
-    //let optimizer_results = optimizer::process_data(vec, tag);
     // Create Optimization Plan and Stream for the data.
     let mut op = OptimizerPlan::plan(vec);
     let mut cs = CompressedStream::new();
+    let mut frame_number = 1;
     // Assign the compressor if it was selected
     match arguments.compressor {
         CompressorType::Noop => op.set_compressor(Compressor::Noop),
@@ -144,7 +144,8 @@ fn compress_data(vec: &[f64], arguments: &Args) -> Vec<u8> {
         CompressorType::Auto => op.set_compressor(Compressor::Auto),
     }
     for (cpr, data) in op.get_execution().into_iter() {
-        debug!("Chunk size: {}", data.len());
+        debug!("--- Frame {}. Chunk size: {}", frame_number, data.len());
+        frame_number += 1;
         // If compressor is a lossy one, compress with the error defined, or default
         match arguments.compressor {
             CompressorType::Fft

--- a/atsc/src/main.rs
+++ b/atsc/src/main.rs
@@ -137,6 +137,7 @@ fn compress_data(vec: &[f64], arguments: &Args) -> Vec<u8> {
     match arguments.compressor {
         CompressorType::Noop => op.set_compressor(Compressor::Noop),
         CompressorType::Constant => op.set_compressor(Compressor::Constant),
+        CompressorType::Rle => op.set_compressor(Compressor::RLE),
         CompressorType::Fft => op.set_compressor(Compressor::FFT),
         CompressorType::Polynomial => op.set_compressor(Compressor::Polynomial),
         CompressorType::Idw => op.set_compressor(Compressor::Idw),
@@ -144,7 +145,7 @@ fn compress_data(vec: &[f64], arguments: &Args) -> Vec<u8> {
     }
     for (cpr, data) in op.get_execution().into_iter() {
         debug!("Chunk size: {}", data.len());
-        // If compressor is a losseless one, compress with the error defined, or default
+        // If compressor is a lossy one, compress with the error defined, or default
         match arguments.compressor {
             CompressorType::Fft
             | CompressorType::Polynomial
@@ -155,6 +156,7 @@ fn compress_data(vec: &[f64], arguments: &Args) -> Vec<u8> {
                 arguments.error as f32 / 100.0,
                 arguments.compression_selection_sample_level as usize,
             ),
+            // If compressor is a lossless one, just compress
             _ => cs.compress_chunk_with(data, cpr.to_owned()),
         }
     }
@@ -225,6 +227,7 @@ enum CompressorType {
     Constant,
     Polynomial,
     Idw,
+    Rle,
 }
 
 fn main() {

--- a/atsc/src/optimizer/utils.rs
+++ b/atsc/src/optimizer/utils.rs
@@ -158,6 +158,7 @@ fn split_n(x: f64) -> (i64, f64) {
         (0, 0.0)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/atsc/tests/e2e.rs
+++ b/atsc/tests/e2e.rs
@@ -34,6 +34,11 @@ fn test_compressor_noop() {
 }
 
 #[test]
+fn test_compressor_rle() {
+    test_lossless_compression("rle")
+}
+
+#[test]
 fn test_compressor_fft_lossy() {
     test_lossy_compression("fft")
 }

--- a/atsc/tests/integration_test.rs
+++ b/atsc/tests/integration_test.rs
@@ -42,6 +42,11 @@ fn test_polynomial() {
 }
 
 #[test]
+fn test_rle() {
+    test_suite("rle");
+}
+
+#[test]
 fn test_auto() {
     test_suite("auto");
 }


### PR DESCRIPTION
# This PR adds RLE to ATSC.

The major driver is that it does what `Constant` does but much more with a minimal impact on space usage. The initial idea was to remove `Constant` from ATSC when adding this but given the simplicity of `Constant` it has no impact on the codebase.

RLE will cover cases where `Constant` couldn't be due to very minor variances in data. And any other compressor would have somewhat weird outputs (e.g. FFT for a histogram kind of data series).

## The inner details:

- Index-based RLE, tradeoff code complexity for better space usage (especially when alternating between a series of the same numbers)
- BTreeMap vs HashMap, BTreeMap does have worse performance but gives determinist output. This way the same input always has the same binary output (which is important).
- RLE is now part of the `AUTO` selection of compressions, this slows down `AUTO` operation, improved statistics should be used to avoid this (for of a later PR).
- It is lossless.

## Why index based RLE vs regular RLE?

In the worst case, we are looking at the same storage requirements, in the best case, savings are noticeable. A couple of examples bellow, assuming every single value uses 4 Bytes. 

### Example 1: Long Consecutive Runs
Consider a sequence with long consecutive runs of the same value:
[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]

**Standard RLE Encoding:**
[(1, 20)]

- Storage required: 8 bytes (4 bytes for the value + 4 bytes for the count).

**Index-Based RLE Encoding:**
[(1, (0))]

- Storage required: 8 bytes (4 bytes for the value + 4 bytes for the single index).

### Example 2: Mixed Short and Long Runs
Consider a sequence with mixed short and long runs:
[1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4]

**Standard RLE Encoding:**
[(1, 2), (2, 3), (3, 4), (4, 5)]

- Storage required: 32 bytes (4 pairs × 8 bytes each).

**Index-Based RLE Encoding:**
[(1, (0)), (2, (2)), (3, (5)), (4, (9))]

- Storage required: 32 bytes (4 pairs × 8 bytes each).

### Example 3: Frequent Short Runs
Consider a sequence with frequent short runs:
[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]

**Standard RLE Encoding:**
[(1, 1), (2, 1), (1, 1), (2, 1), (1, 1), (2, 1), (1, 1), (2, 1), (1, 1), (2, 1)]

- Storage required: 80 bytes (10 pairs × 8 bytes each).

**Index-Based RLE Encoding:**
[(1, (0, 2, 4, 6, 8)), (2, (1, 3, 5, 7, 9))]

- Storage required: 48 bytes (2 pairs × 4 bytes for the value + 5 indexes × 4 bytes each).

### Example 4: Sparse Repetitions
Consider a sequence with sparse repetitions:
[1, 2, 3, 4, 1, 5, 6, 1, 7, 8, 1, 9, 10, 1]

**Standard RLE Encoding:**
[(1, 1), (2, 1), (3, 1), (4, 1), (1, 1), (5, 1), (6, 1), (1, 1), (7, 1), (8, 1), (1, 1), (9, 1), (10, 1), (1, 1)]

- Storage required: 112 bytes (14 pairs × 8 bytes each).

**Index-Based RLE Encoding:**
[(1, (0, 4, 7, 10, 13)), (2, (1)), (3, (2)), (4, (3)), (5, (5)), (6, (6)), (7, (8)), (8, (9)), (9, (11)), (10, (12))]

- Storage required: 64 bytes (10 pairs × 4 bytes for the value + 5 indexes × 4 bytes each for the value 1, and 1 index × 4 bytes each for other values).
